### PR TITLE
Add OpenClaw latency baseline tooling

### DIFF
--- a/docs/openclaw-baseline.md
+++ b/docs/openclaw-baseline.md
@@ -1,0 +1,60 @@
+# OpenClaw latency and throughput baseline
+
+Run this baseline **before** changing the model tier, queue mode, or worker
+concurrency. It measures completed user task events, not synthetic probes.
+
+## Event export contract
+
+Export one JSON object per task to JSONL. Required fields are `received_at`,
+`started_at`, `completed_at`, and `status` (`success` or `failed`). Timestamps
+must be ISO-8601 UTC. Include `retry_count` (zero when no retry) and the
+optional timestamp pairs below when the task reaches those layers:
+
+| Metric | Timestamp pair |
+| --- | --- |
+| model latency | `model_started_at` → `model_completed_at` |
+| connector latency | `connector_started_at` → `connector_completed_at` |
+| gateway latency | `gateway_started_at` → `gateway_completed_at` |
+
+Mark health checks and telemetry with `"traffic_class":"monitoring"` (or
+`"monitoring":true`). The analyzer excludes them. Collect health status from a
+cached snapshot created before the run; do not issue health probes as part of
+the measurement window. Health snapshot records are operational context, not
+task events, and are not included in the report.
+
+## Run and record
+
+```sh
+python3 tools/openclaw_baseline.py --input artifacts/openclaw-events.jsonl \
+  --output artifacts/openclaw-baseline.json
+```
+
+Attach the input window, cached health snapshot timestamp, generated report,
+model tier, queue mode, worker count, and write-approval policy to the change
+record. Keep the existing response-quality evaluation and write approvals in
+place; this tool neither sends tasks nor changes approvals.
+
+The report gives p50/p95 task latency and queue wait, separated p50/p95 model,
+connector, and gateway latency, failure rate, total retries, and completed-task
+throughput. Missing component timestamps are reported as zero samples rather
+than being guessed.
+
+## Concurrency decision and rollback
+
+Do not raise concurrency from this report alone. A bounded change is eligible
+only when the report has a positive queue-wait p95 **and** identifies a
+component bottleneck; investigate that bottleneck first. Start with the
+smallest worker increment and repeat the exact export window and quality set.
+
+Record these rollback thresholds before applying the change:
+
+| Signal | Roll back when |
+| --- | --- |
+| p95 task latency | more than 20% above the approved baseline |
+| failure rate | more than 1 percentage point above baseline |
+| retry count per task | more than 25% above baseline |
+| response quality or write approval | any regression or approval bypass |
+
+Roll back to the prior model tier, queue mode, and worker bound immediately if
+any threshold is crossed. Preserve both baseline and post-change reports so the
+decision is auditable.

--- a/test/test_openclaw_baseline.py
+++ b/test/test_openclaw_baseline.py
@@ -1,0 +1,33 @@
+import importlib.util
+import unittest
+
+
+spec = importlib.util.spec_from_file_location("baseline", "tools/openclaw_baseline.py")
+baseline = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(baseline)
+
+
+class BaselineTests(unittest.TestCase):
+    def test_excludes_monitoring_and_separates_latency_layers(self):
+        events = [
+            {"received_at": "2026-07-16T00:00:00Z", "started_at": "2026-07-16T00:00:01Z", "completed_at": "2026-07-16T00:00:11Z", "model_started_at": "2026-07-16T00:00:02Z", "model_completed_at": "2026-07-16T00:00:05Z", "connector_started_at": "2026-07-16T00:00:05Z", "connector_completed_at": "2026-07-16T00:00:07Z", "gateway_started_at": "2026-07-16T00:00:07Z", "gateway_completed_at": "2026-07-16T00:00:11Z", "status": "success", "retry_count": 2},
+            {"received_at": "2026-07-16T00:00:00Z", "started_at": "2026-07-16T00:00:02Z", "completed_at": "2026-07-16T00:00:12Z", "status": "failed", "retry_count": 1},
+            {"traffic_class": "monitoring", "received_at": "2026-07-16T00:00:00Z", "started_at": "2026-07-16T00:00:01Z", "completed_at": "2026-07-16T00:01:00Z", "status": "success"},
+        ]
+        report = baseline.summarize(events)
+        self.assertEqual(report["included_task_events"], 2)
+        self.assertEqual(report["monitoring_events_excluded"], 1)
+        self.assertEqual(report["failure_rate"], 0.5)
+        self.assertEqual(report["retry_count"], 3)
+        self.assertEqual(report["metrics"]["task_latency_ms"]["p50_ms"], 11500.0)
+        self.assertEqual(report["metrics"]["model_latency_ms"]["p95_ms"], 3000.0)
+        self.assertEqual(report["metrics"]["connector_latency_ms"]["p50_ms"], 2000.0)
+        self.assertEqual(report["metrics"]["gateway_latency_ms"]["p50_ms"], 4000.0)
+
+    def test_declines_concurrency_change_without_queueing(self):
+        report = baseline.summarize([{"received_at": "2026-07-16T00:00:00Z", "started_at": "2026-07-16T00:00:00Z", "completed_at": "2026-07-16T00:00:01Z", "status": "success"}])
+        self.assertIn("Do not change concurrency", report["concurrency_recommendation"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/openclaw_baseline.py
+++ b/tools/openclaw_baseline.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Produce a comparable OpenClaw latency baseline from task-event JSONL.
+
+The input is deliberately an export format rather than a live probe: health
+checks remain cached and monitoring traffic cannot pollute task measurements.
+See docs/openclaw-baseline.md for the event contract.
+"""
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+TIME_FIELDS = {
+    "task_latency_ms": ("received_at", "completed_at"),
+    "queue_wait_ms": ("received_at", "started_at"),
+    "model_latency_ms": ("model_started_at", "model_completed_at"),
+    "connector_latency_ms": ("connector_started_at", "connector_completed_at"),
+    "gateway_latency_ms": ("gateway_started_at", "gateway_completed_at"),
+}
+
+
+def parse_time(value):
+    """Return a timezone-aware timestamp, accepting the normal ISO-8601 Z form."""
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def duration_ms(event, start, end):
+    first, last = parse_time(event.get(start)), parse_time(event.get(end))
+    if not first or not last:
+        return None
+    return round((last - first).total_seconds() * 1000, 3)
+
+
+def percentile(values, percentile):
+    """Linearly interpolated percentile, stable for small baseline samples."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * percentile
+    lower, upper = int(position), min(int(position) + 1, len(ordered) - 1)
+    return round(ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower), 3)
+
+
+def is_monitoring(event):
+    return event.get("traffic_class") == "monitoring" or event.get("monitoring") is True
+
+
+def summarize(events):
+    """Summarize completed task events and return a JSON-serializable report."""
+    included = [event for event in events if not is_monitoring(event)]
+    monitoring_excluded = len(events) - len(included)
+    metrics = {name: [] for name in TIME_FIELDS}
+    statuses = Counter()
+    retries = 0
+    completed_times = []
+
+    for event in included:
+        statuses[event.get("status", "unknown")] += 1
+        retries += max(0, int(event.get("retry_count", 0)))
+        completed = parse_time(event.get("completed_at"))
+        if completed:
+            completed_times.append(completed)
+        for name, (start, end) in TIME_FIELDS.items():
+            value = duration_ms(event, start, end)
+            if value is not None and value >= 0:
+                metrics[name].append(value)
+
+    total = len(included)
+    metric_report = {
+        name: {"samples": len(values), "p50_ms": percentile(values, .50), "p95_ms": percentile(values, .95)}
+        for name, values in metrics.items()
+    }
+    elapsed_seconds = (max(completed_times) - min(completed_times)).total_seconds() if len(completed_times) > 1 else 0
+    throughput = None if elapsed_seconds == 0 else round(len(completed_times) / elapsed_seconds, 3)
+    component_p95 = {
+        name: data["p95_ms"] for name, data in metric_report.items()
+        if name not in {"task_latency_ms", "queue_wait_ms"} and data["p95_ms"] is not None
+    }
+    bottleneck = max(component_p95, key=component_p95.get) if component_p95 else None
+    queue_p95 = metric_report["queue_wait_ms"]["p95_ms"]
+    recommendation = (
+        "Investigate %s before changing concurrency; queueing is measurable." % bottleneck
+        if bottleneck and queue_p95 and queue_p95 > 0 else
+        "Do not change concurrency: this baseline does not show measurable queueing and a component bottleneck."
+    )
+    return {
+        "included_task_events": total,
+        "monitoring_events_excluded": monitoring_excluded,
+        "health_snapshot_policy": "cached snapshots only; health snapshot events are not task measurements",
+        "metrics": metric_report,
+        "failure_rate": round(statuses["failed"] / total, 6) if total else None,
+        "failure_count": statuses["failed"],
+        "retry_count": retries,
+        "throughput_tasks_per_second": throughput,
+        "bottleneck_candidate": bottleneck,
+        "concurrency_recommendation": recommendation,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="JSONL task-event export")
+    parser.add_argument("--output", type=Path, help="write report here instead of stdout")
+    args = parser.parse_args()
+    with args.input.open(encoding="utf-8") as source:
+        events = [json.loads(line) for line in source if line.strip()]
+    rendered = json.dumps(summarize(events), indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a reproducible baseline of OpenClaw task latency and throughput before changing model tier, queue mode, or worker concurrency.
- Capture p50/p95 task latency, queue wait, failure rate, and retry count while separating model, connector, and gateway latency.
- Exclude monitoring/health-check traffic and require cached health snapshots so measurements are not polluted by probes.
- Document bounded-concurrency decision criteria and explicit rollback thresholds to preserve response quality and approvals.

### Description
- Add `tools/openclaw_baseline.py`, a dependency-free JSONL analyzer that computes p50/p95 for `task_latency_ms`, `queue_wait_ms`, `model_latency_ms`, `connector_latency_ms`, and `gateway_latency_ms`, counts failures/retries, estimates throughput, excludes monitoring traffic, and emits a JSON report with a bottleneck candidate and a concurrency recommendation.
- Add `docs/openclaw-baseline.md` documenting the event export contract, run instructions using `python3 tools/openclaw_baseline.py`, guidance for concurrency decisions, and rollback thresholds.
- Add unit tests in `test/test_openclaw_baseline.py` that cover monitoring exclusion, layer-specific metric separation, retry/failure aggregation, and the recommendation behavior when no queueing is present.
- Commit is self-contained and dependency-free (pure Python), and designed to run from exported JSONL task-event traces without issuing any live probes.

### Testing
- Ran `python3 -m unittest discover -s test -v` and all tests passed (`OK`).
- Ran `python3 -m py_compile tools/openclaw_baseline.py` and the module compiled successfully.
- Ran `git diff --check` with no issues reported.
- Attempted `script/cibuild` but it failed due to the environment missing the `jekyll` gem executable (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58fe682a58832fb2cf41e6ff824842)

### Linear
Fixes HEL-8
