### PR TITLE
Add read-only OpenClaw OAuth guardian

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,27 @@ I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey t
 
 I'll meet you over there, can't wait to get started!
 
+## OpenClaw OAuth guardian
+
+`script/openclaw-oauth-guardian` is a read-only operational check for the
+canonical OpenAI OAuth identity: provider `openai`, profile `openai:default`.
+It lets OpenClaw own OAuth refreshes and only alerts an operator when that
+profile is absent or OpenClaw reports a permanent refresh rejection. It never
+starts a login, refreshes a token, probes a model or channel, or changes model
+selection.
+
+The guardian reads `openclaw models auth list --provider openai --json` and
+`openclaw models status --check --json`, and records the cached
+`openclaw health --json` snapshot for diagnosis. Alerts are one per incident
+kind for 24 hours by default. Set `OPENCLAW_ALERT_COMMAND` to a command that
+accepts the alert text as its first argument; otherwise the alert is written to
+standard error. `XDG_STATE_HOME`, `OPENCLAW_PROVIDER_ID`,
+`OPENCLAW_PROFILE_ID`, and `OPENCLAW_ALERT_COOLDOWN_SECONDS` are configurable.
+
+Run the regression check with:
+
+```sh
+test/openclaw-oauth-guardian-test.sh
+```
+
 This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.

--- a/script/openclaw-oauth-guardian
+++ b/script/openclaw-oauth-guardian
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# Read-only OpenClaw OAuth guardian.  Token refresh and the OAuth flow belong
+# to OpenClaw; this script only decides whether an operator needs to act.
+set -eu
+
+provider=${OPENCLAW_PROVIDER_ID:-openai}
+profile=${OPENCLAW_PROFILE_ID:-openai:default}
+state_dir=${XDG_STATE_HOME:-"$HOME/.local/state"}/openclaw-oauth-guardian
+cooldown_seconds=${OPENCLAW_ALERT_COOLDOWN_SECONDS:-86400}
+mkdir -p "$state_dir"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf '%s\n' "openclaw-oauth-guardian: required command not found: $1" >&2
+    exit 127
+  }
+}
+
+require_command openclaw
+require_command jq
+
+# Health is deliberately collected once through OpenClaw's cached health
+# snapshot. Do not add --probe, channel checks, or model selection commands.
+health=$(openclaw health --json 2>/dev/null || true)
+printf '%s\n' "$health" >"$state_dir/health.json"
+
+auth=$(openclaw models auth list --provider "$provider" --json)
+status_exit=0
+status=$(openclaw models status --check --json) || status_exit=$?
+
+has_profile=$(printf '%s\n' "$auth" | jq -e --arg provider "$provider" --arg profile "$profile" '
+  .. | objects |
+  select((.provider? == $provider or .providerId? == $provider) and
+         (.id? == $profile or .profileId? == $profile))
+' >/dev/null && printf yes || printf no)
+
+# A status check can also report an ordinary expiry or transient outage. Those
+# are OpenClaw's responsibility and must not trigger an OAuth login prompt.
+permanent_rejection=$(printf '%s\n' "$status" | jq -r '.. | strings' | \
+  tr '[:upper:]' '[:lower:]' | \
+  grep -E -m1 'invalid_grant|invalid[_ -]?token|refresh[_ -]?token.*(revoked|rejected)|permanent.*(reject|fail)|reauth' \
+  >/dev/null && printf yes || printf no)
+
+incident=''
+if [ "$has_profile" = no ]; then
+  incident='missing-profile'
+elif [ "$status_exit" -ne 0 ] && [ "$permanent_rejection" = yes ]; then
+  incident='permanent-refresh-rejection'
+fi
+
+[ -n "$incident" ] || exit 0
+
+now=$(date +%s)
+stamp="$state_dir/$incident.last-alert"
+last=0
+[ -f "$stamp" ] && last=$(cat "$stamp" 2>/dev/null || printf 0)
+case $last in *[!0-9]*|'') last=0 ;; esac
+
+if [ $((now - last)) -lt "$cooldown_seconds" ]; then
+  exit 0
+fi
+
+printf '%s\n' "$now" >"$stamp"
+message="OpenClaw OAuth needs attention: $incident for $provider profile $profile. Run: openclaw models auth login --provider $provider --profile-id $profile"
+if [ -n "${OPENCLAW_ALERT_COMMAND:-}" ]; then
+  "$OPENCLAW_ALERT_COMMAND" "$message"
+else
+  printf '%s\n' "$message" >&2
+fi

--- a/test/openclaw-oauth-guardian-test.sh
+++ b/test/openclaw-oauth-guardian-test.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/state"
+
+cat >"$tmp/bin/openclaw" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$OPENCLAW_CALL_LOG"
+case "$*" in
+  'health --json') printf '%s\n' '{"cached":true}' ;;
+  'models auth list --provider openai --json') printf '%s\n' "$OPENCLAW_AUTH_JSON" ;;
+  'models status --check --json') printf '%s\n' "$OPENCLAW_STATUS_JSON"; exit "${OPENCLAW_STATUS_EXIT:-0}" ;;
+  *) exit 99 ;;
+esac
+EOF
+cat >"$tmp/bin/jq" <<'EOF'
+#!/bin/sh
+exec /usr/bin/jq "$@"
+EOF
+cat >"$tmp/bin/alert" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$1" >>"$OPENCLAW_ALERT_LOG"
+EOF
+chmod +x "$tmp/bin/openclaw" "$tmp/bin/jq" "$tmp/bin/alert" "$root/script/openclaw-oauth-guardian"
+
+run_guardian() {
+  PATH="$tmp/bin:$PATH" XDG_STATE_HOME="$tmp/state" OPENCLAW_CALL_LOG="$tmp/calls" \
+    OPENCLAW_ALERT_LOG="$tmp/alerts" OPENCLAW_ALERT_COMMAND="$tmp/bin/alert" \
+    OPENCLAW_AUTH_JSON="$1" OPENCLAW_STATUS_JSON="$2" OPENCLAW_STATUS_EXIT="${3:-0}" \
+    "$root/script/openclaw-oauth-guardian"
+}
+
+run_guardian '{"profiles":[]}' '{"auth":{"oauth":[]}}'
+test "$(wc -l <"$tmp/alerts")" -eq 1
+grep -q 'missing-profile' "$tmp/alerts"
+! grep -E 'login|refresh|models set|probe' "$tmp/calls"
+
+# The same incident cannot page twice within the default 24-hour cooldown.
+run_guardian '{"profiles":[]}' '{"auth":{"oauth":[]}}'
+test "$(wc -l <"$tmp/alerts")" -eq 1
+
+rm -rf "$tmp/state"; mkdir -p "$tmp/state"
+run_guardian '{"profiles":[{"provider":"openai","id":"openai:default"}]}' \
+  '{"error":"invalid_grant: refresh token revoked"}' 1
+grep -q 'permanent-refresh-rejection' "$tmp/alerts"
+
+# Expiry alone is not a permanent rejection and must not force reauthentication.
+rm -rf "$tmp/state"; mkdir -p "$tmp/state"
+before=$(wc -l <"$tmp/alerts")
+run_guardian '{"profiles":[{"provider":"openai","id":"openai:default"}]}' \
+  '{"error":"token expired"}' 1
+test "$(wc -l <"$tmp/alerts")" -eq "$before"


### PR DESCRIPTION
### Motivation

- Provide an operational guardian that monitors the canonical OpenAI OAuth profile without performing refreshes or forced reauthentication. 
- Rely on OpenClaw's own auth inventory and cached health snapshot to avoid side-script token refreshes or model/channel probes. 
- Alert operators only for missing profiles or permanent refresh rejections and prevent alert spam with a per-incident cooldown. 

### Description

- Add `script/openclaw-oauth-guardian`, a read-only shell guardian that records `openclaw health --json`, reads `openclaw models auth list --provider <provider> --json`, and evaluates `openclaw models status --check --json` to decide operator action. 
- Detects two incident kinds (`missing-profile` and `permanent-refresh-rejection`) using provider-filtered auth inventory and a regex-based scan of status output, and writes one alert per incident with a cooldown file stored under `XDG_STATE_HOME` (default `~/.local/state`). 
- Exposes configuration via environment variables `OPENCLAW_PROVIDER_ID`, `OPENCLAW_PROFILE_ID`, `OPENCLAW_ALERT_COMMAND`, `OPENCLAW_ALERT_COOLDOWN_SECONDS`, and `XDG_STATE_HOME`, and never initiates login/refresh/model selection/probes. 
- Add regression `test/openclaw-oauth-guardian-test.sh` which simulates `openclaw` calls to validate alerting, cooldown behavior, that no auth flows or probes are invoked, and that ordinary expiry does not force reauthentication, and update `README.md` with usage and configuration notes. 

### Testing

- Ran shell syntax checks with `dash -n script/openclaw-oauth-guardian` and `dash -n test/openclaw-oauth-guardian-test.sh`, and executed the test harness with `test/openclaw-oauth-guardian-test.sh`, all of which completed successfully. 
- Verified `git diff --check` succeeded with no whitespace errors. 
- The test suite confirms: a single alert for a missing profile, cooldown prevents duplicate alerts within the default 24-hour window, permanent refresh rejection produces an alert, and a simple token expiry does not trigger reauthentication. 
- Note: `shellcheck` was not available in the environment so script linting with `shellcheck` was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58fecc1094832f9987e88b4a79a3f5)

### Linear
Fixes HEL-5
