### PR TITLE
Add rate limit recovery slide

### DIFF
--- a/_posts/0000-01-02-rate-limit-recovery.md
+++ b/_posts/0000-01-02-rate-limit-recovery.md
@@ -1,0 +1,14 @@
+---
+layout: slide
+title: "Rate limit recovery playbook"
+---
+
+## 자동화봇 응답 지연 해결
+
+If every model says it is temporarily rate-limited, pause retries and let the approval settle.
+
+1. Reply with the exact `/approve plugin:<id> allow-once` command once.
+2. Wait a few minutes before sending another prompt.
+3. If the warning repeats, switch to a lighter model or retry after the rate-limit window resets.
+
+Use the left arrow to go back!


### PR DESCRIPTION
### Motivation
- Provide a short troubleshooting slide explaining recovery steps when the Telegram/OpenClo automation bot responds "All models are temporarily rate-limited" after an approval prompt.

### Description
- Add a new Jekyll slide at `_posts/0000-01-02-rate-limit-recovery.md` containing a brief playbook instructing users to send `/approve plugin:<id> allow-once` once, wait a few minutes, and retry or switch to a lighter model; the file was committed to the branch.

### Testing
- Attempted `bundle exec jekyll build` (failed because `jekyll` was not available) and `bundle install` (failed due to Bundler 2.2.9 compatibility error on Ruby 3.4.4 / `DidYouMean`), so automated build/tests are currently blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e03d1d654832faa221998c9c53d29)